### PR TITLE
summaryLength in config.toml

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -3,6 +3,7 @@ themesDir = "themes"
 theme = "hugo-serif-theme"
 languageCode = "en-us"
 title = "Hugo Serif Theme"
+summaryLength = 10
 
 [module]
   [module.hugoVersion]


### PR DESCRIPTION
Services on the homepage show a lot of content text. Adding this parameter in config.toml helps to show exactly how much text you want to show here.